### PR TITLE
Mistakes/typos in `Specifications.swift` file.

### DIFF
--- a/SnappyShrimp/Sources/Logic/Specifications.swift
+++ b/SnappyShrimp/Sources/Logic/Specifications.swift
@@ -99,7 +99,7 @@ extension UITraitCollection {
         static let landscape = UITraitCollection(
             traitsFrom: [Display.InterfaceIdiom.phone,
                          Display.SizeClass.Vertical.compact,
-                         Display.SizeClass.Horizontal.compact,
+                         Display.SizeClass.Horizontal.regular,
                          Display.Scale.x3,
                          Compability.ForceTouch.available,
                          Compability.DisplayGamut.P3])
@@ -180,7 +180,7 @@ extension CGSize {
     static let iPhone4S = CGSize(width: 320, height: 480)
     static let iPhoneSE = CGSize(width: 320, height: 568)
     static let iPhoneX = CGSize(width: 375, height: 812)
-    static let iPhoneXR = CGSize(width: 413, height: 896)
+    static let iPhoneXR = CGSize(width: 414, height: 896)
     static let iPhoneXSMax = CGSize(width: 414, height: 896)
     static let iPhone = CGSize(width: 375, height: 667)
     static let iPhonePlus = CGSize(width: 414, height: 736)


### PR DESCRIPTION
<!-- Thanks for contributing to the Snappy Shrimp! Please make sure to check the following boxes by putting an x in the [ ] -->
### Checklist

- [x] I've read [contribution guidelines](https://github.com/AndriiDoroshko/SnappyShrimp/new/master/.github/CONTRIBUTING.md);
- [x] I've tested these updates in the SnappyShrimpExample; 
- [x] This pull request is complete and ready for review.

### Description

It seams that there is a typo in `width` of `iPhoneXR` property. 
Also size class of `iPhoneXSMax` in landscape should be _vertical compact, horizontal **regular**_.
<!-- Add a description for the PR --> 
<!-- If there's an open issue for that PR, don't forget to specify it as #xxx - where xxx is a number of the issue. --> 

