### PR TITLE
XCode 11.4 build

### DIFF
--- a/SnappyShrimp.xcodeproj/project.pbxproj
+++ b/SnappyShrimp.xcodeproj/project.pbxproj
@@ -595,7 +595,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/usr/lib";
-				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.RomanTysiachnik.SnappyShrimp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -625,7 +624,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/usr/lib";
-				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.RomanTysiachnik.SnappyShrimp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/SnappyShrimp.xcodeproj/project.pbxproj
+++ b/SnappyShrimp.xcodeproj/project.pbxproj
@@ -594,6 +594,8 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SnappyShrimp/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/usr/lib";
+				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.RomanTysiachnik.SnappyShrimp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -622,6 +624,8 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SnappyShrimp/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/usr/lib";
+				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.RomanTysiachnik.SnappyShrimp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
<!-- Thanks for contributing to the Snappy Shrimp! Please make sure to check the following boxes by putting an x in the [ ] -->
### Checklist

- [x] I've read [contribution guidelines](https://github.com/AndriiDoroshko/SnappyShrimp/new/master/.github/CONTRIBUTING.md);
- [x] I've tested these updates in the SnappyShrimpExample; 
- [x] This pull request is complete and ready for review.

### Description

<!-- Add a description for the PR --> 
<!-- If there's an open issue for that PR, don't forget to specify it as #xxx - where xxx is a number of the issue. --> 
Resolves #10 
Explicitly added linking to "XCTestSwiftSupport" lib and a search path for it to satisfy XCode 11.4 compiler.
Perhaps this is a temporary solution, as it seems that Apple did some changes in their test libs recently and maybe it won't be needed after a few new XCode releases. Anyway, current solution is based on [similar issue resolution](https://github.com/CocoaPods/CocoaPods/issues/9165#issuecomment-550273696).

P.S. 
Contribution guidelines link in the template is broken.

P.P.S.
I could not find anything named "SnappyShrimpExample" in the repo or Github itself. Is it outdated?
